### PR TITLE
Updated documentation for Humble. 

### DIFF
--- a/software/simulation.md
+++ b/software/simulation.md
@@ -6,15 +6,19 @@ sort: 10
 
 The simulator allows the user to test the robot without the need for a physical robot. It has all of the same functionality as the real robot. The TurtleBot 4 can be simulated using [Gazebo](http://gazebosim.org/) (previously known as Ignition Gazebo). Unlike [Gazebo Classic](https://classic.gazebosim.org/), Gazebo does not natively support ROS. Instead, it has its own transport stack with a similar topic and node implementation. To communicate with ROS, we can use the [ros_ign_bridge](https://github.com/gazebosim/ros_gz/tree/humble/ros_gz_bridge). This ROS node translates data from ROS to Ignition, and vice versa.
 
-```note
-The simulation is not yet available in ROS 2 Humble.
-```
 
 ## Installing Ignition Gazebo
 
 Requirements:
 - Ubuntu 20.04
 - ROS 2 Galactic
+
+or
+
+- Ubuntu 22.04
+- ROS 2 Humble
+
+
 
 Recommended:
 - PC with dedicated GPU


### PR DESCRIPTION
I found some outdated documentation on the simulation page while reading through it. Small change editing out text mentioning incompatibility with humble. Possibly consider combining files "turtlebot4_simulator.md" and "simulation.md" for more concise documentation. 