### PR TITLE
Fix/apply settings

### DIFF
--- a/setup/basic.md
+++ b/setup/basic.md
@@ -120,7 +120,8 @@ In your SSH session, run the [TurtleBot 4 setup tool](../software/turtlebot4_set
 turtlebot4-setup
 ```
 
-This will start the TurtleBot 4 setup tool. Navigate to the "Wi-Fi Setup" menu and configure your connection. When you have finished, save and apply the settings.
+This will start the TurtleBot 4 setup tool. Navigate to the "Wi-Fi Setup" menu and configure your connection. When you have finished, save the wifi settings, then
+return to the main menu. Select `Apply Settings` and press `Enter` before quitting the `turtlebot4-setup` tool.
 
 <figure class="aligncenter">
     <img src="media/wifi_setup.gif" alt="Wi-Fi setup" style="width: 100%"/>
@@ -140,7 +141,8 @@ In your SSH session, run the [TurtleBot 4 setup tool](../software/turtlebot4_set
 turtlebot4-setup
 ```
 
-This will start the TurtleBot 4 setup tool. Navigate to the "Wi-Fi Setup" menu and configure your connection. When you have finished, save and apply the settings.
+This will start the TurtleBot 4 setup tool. Navigate to the "Wi-Fi Setup" menu and configure your connection. When you have finished, save the wifi settings, then
+return to the main menu. Select `Apply Settings` and press `Enter` before quitting the `turtlebot4-setup` tool.
 
 <figure class="aligncenter">
     <img src="media/wifi_setup.gif" alt="Wi-Fi setup" style="width: 100%"/>
@@ -365,7 +367,8 @@ SSH into the Raspberry Pi and run the [TurtleBot 4 setup tool](../software/turtl
 turtlebot4-setup
 ```
 
-Go to <b>Wi-Fi Setup</b> and select <b>Apply Defaults</b>. Optionally you can set your own SSID and password before saving and applying the new settings.
+Go to <b>Wi-Fi Setup</b> and select <b>Apply Defaults</b>. Optionally you can set your own SSID and password before saving. Return to the main menu and select
+`Apply Settings` and press `Enter` before quitting the `turtlebot4-setup` tool.
 
 {% endtab %}
 {% tab ap jazzy %}
@@ -376,7 +379,8 @@ SSH into the Raspberry Pi and run the [TurtleBot 4 setup tool](../software/turtl
 turtlebot4-setup
 ```
 
-Go to <b>Wi-Fi Setup</b> and select <b>Apply Defaults</b>. Optionally you can set your own SSID and password before saving and applying the new settings.
+Go to <b>Wi-Fi Setup</b> and select <b>Apply Defaults</b>. Optionally you can set your own SSID and password before saving. Return to the main menu and select
+`Apply Settings` and press `Enter` before quitting the `turtlebot4-setup` tool.
 
 {% endtab %}
 {% endtabs %}

--- a/software/turtlebot4_setup.md
+++ b/software/turtlebot4_setup.md
@@ -246,6 +246,11 @@ You will be greeted by a menu with several submenus. From here you can navigate 
 <br/>
 <u><b style="font-size: 20px;">Usage</b></u>
 
+```warning
+You _must_ select the `Apply Settings` option and press `Enter` before quitting to apply any changes you have made to the robot.
+Quitting without applying the settings will discard any changes you have staged.
+```
+
 You can navigate up and down between the menus by using the `up` and `down` arrow keys, or `j` and `k`. To select a menu,
 press `Enter`. To return or exit from a menu, you can press `q`, `Esc`, or `CTRL+C`. Some menus may only be exited with `CTRL+C`.
 
@@ -572,6 +577,11 @@ You will be greeted by a menu with several submenus. From here you can navigate 
 
 <br/>
 <u><b style="font-size: 20px;">Usage</b></u>
+
+```warning
+You _must_ select the `Apply Settings` option and press `Enter` before quitting to apply any changes you have made to the robot.
+Quitting without applying the settings will discard any changes you have staged.
+```
 
 You can navigate up and down between the menus by using the `up` and `down` arrow keys, or `j` and `k`. To select a menu,
 press `Enter`. To return or exit from a menu, you can press `q`, `Esc`, or `CTRL+C`. Some menus may only be exited with `CTRL+C`.

--- a/software/turtlebot4_setup.md
+++ b/software/turtlebot4_setup.md
@@ -247,8 +247,7 @@ You will be greeted by a menu with several submenus. From here you can navigate 
 <u><b style="font-size: 20px;">Usage</b></u>
 
 ```warning
-You _must_ select the `Apply Settings` option and press `Enter` before quitting to apply any changes you have made to the robot.
-Quitting without applying the settings will discard any changes you have staged.
+You _must_ select the `Apply Settings` option and press `Enter` before quitting to apply any changes you have made to the robot. Quitting without applying the settings will discard any changes you have staged.
 ```
 
 You can navigate up and down between the menus by using the `up` and `down` arrow keys, or `j` and `k`. To select a menu,
@@ -579,8 +578,7 @@ You will be greeted by a menu with several submenus. From here you can navigate 
 <u><b style="font-size: 20px;">Usage</b></u>
 
 ```warning
-You _must_ select the `Apply Settings` option and press `Enter` before quitting to apply any changes you have made to the robot.
-Quitting without applying the settings will discard any changes you have staged.
+You _must_ select the `Apply Settings` option and press `Enter` before quitting to apply any changes you have made to the robot. Quitting without applying the settings will discard any changes you have staged.
 ```
 
 You can navigate up and down between the menus by using the `up` and `down` arrow keys, or `j` and `k`. To select a menu,


### PR DESCRIPTION
## Description

Explicitly call out that `Apply Settings` from the main menu must be used before quitting the `turtlebot4-setup` tool.

Fixes https://github.com/turtlebot/turtlebot4_setup/issues/23.