### PR TITLE
docs: Adds a missing dependency note for irobot_create_description and fixed issue #45…

### DIFF
--- a/software/turtlebot4_common.md
+++ b/software/turtlebot4_common.md
@@ -55,7 +55,8 @@ sudo apt update
 sudo apt install ros-jazzy-turtlebot4-description \
 ros-jazzy-turtlebot4-msgs \
 ros-jazzy-turtlebot4-navigation \
-ros-jazzy-turtlebot4-node
+ros-jazzy-turtlebot4-node \
+ros-jazzy-irobot-create-description
 ```
 
 {% endtab %}


### PR DESCRIPTION
… (fixes #45)
## Description
Adds a missing dependency note for `irobot_create_description` when building `turtlebot4_description` when following the official user manual.

The current documentation only lists ros-jazzy-turtlebot4-description , ros-jazzy-turtlebot4-msgs ,
ros-jazzy-turtlebot4-navigation , ros-jazzy-turtlebot4-node

This leads to a build failure when users attempt to build the package from source gives error of a missing dependency note for `irobot_create_description`

## Fixes
Fixes #45  >

## How Has This Been Tested?
- Followed the official documentation steps → build failed due to missing `irobot_create_description`
- Installed dependency from source using and  after that no error all build successfully  :

  ```bash
     sudo apt install ros-jazzy-turtlebot4-description \
     ros-jazzy-turtlebot4-msgs \
     ros-jazzy-turtlebot4-navigation \
     ros-jazzy-turtlebot4-node \
     ros-jazzy-irobot-create-description

